### PR TITLE
Fix typo in twindr post

### DIFF
--- a/_posts/0003-01-01-twindr.md
+++ b/_posts/0003-01-01-twindr.md
@@ -33,7 +33,7 @@ meta_description: Twindr app tinder twitter producthunt Richard Kim cwRichardKim
 
 ## WTF (What The Facebook) / Flip The Bird
 
-Jared and I built the basics of the app at the [Tufts University Hackathon](http://2015.polyhack.tufts.io) in late 2014.  Originally, we had planned to focus on unfollowing old Facebook friends instead of Twitter accounts, but we quickly realized how limited the Facebook API was in terms of executing actions on behalf of the the user.
+Jared and I built the basics of the app at the [Tufts University Hackathon](http://2015.polyhack.tufts.io) in late 2014.  Originally, we had planned to focus on unfollowing old Facebook friends instead of Twitter accounts, but we quickly realized how limited the Facebook API was in terms of executing actions on behalf of the user.
 
 ![building twindr](/projects/twindr/building_twindr.png)
 


### PR DESCRIPTION
## Summary
- fix a double word typo in the Twindr post

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850174022e0832b8401e814a06b424f