### PR TITLE
Fix highlight filtering and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _site
 .sass-cache
 .jekyll-metadata
 .DS_Store
+__pycache__/
+tests/__pycache__/

--- a/fetch_highlights.py
+++ b/fetch_highlights.py
@@ -30,11 +30,10 @@ def fetch_exports():
     return all_results
 
 def filter_highlights(highlights):
-    return [h for h in highlights 
-        if any(
-            tag['name'] == 'share' or h['is_favorite']
-            for tag in h.get('tags', [])
-        )
+    return [
+        h for h in highlights
+        if h.get("is_favorite")
+        or any(tag["name"] == "share" for tag in h.get("tags", []))
     ]
 
 def slugify(text):

--- a/tests/test_filter_highlights.py
+++ b/tests/test_filter_highlights.py
@@ -1,0 +1,35 @@
+import pytest
+import sys
+import types
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+
+from fetch_highlights import filter_highlights
+
+
+def test_returns_favorite_highlight():
+    highlights = [{"is_favorite": True, "tags": []}]
+    assert filter_highlights(highlights) == highlights
+
+
+def test_returns_share_tag_highlight():
+    highlights = [{"is_favorite": False, "tags": [{"name": "share"}]}]
+    assert filter_highlights(highlights) == highlights
+
+
+def test_filters_non_matching_highlight():
+    highlights = [{"is_favorite": False, "tags": [{"name": "other"}]}]
+    assert filter_highlights(highlights) == []
+
+
+def test_mixed_highlights():
+    hs = [
+        {"is_favorite": False, "tags": [{"name": "share"}]},
+        {"is_favorite": True, "tags": []},
+        {"is_favorite": False, "tags": []},
+    ]
+    assert filter_highlights(hs) == hs[:2]


### PR DESCRIPTION
## Summary
- refine `filter_highlights` logic
- ignore Python cache directories
- add unit tests for `filter_highlights`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850177c87c0832b96f6489a3da70d2c