### PR TITLE
Add posts page aggregating Substack and Medium writing

### DIFF
--- a/_data/medium_posts.json
+++ b/_data/medium_posts.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "We spent a year building a dating app that only lasts one week",
+    "link": "https://medium.com/@cwRichardKim/we-spent-a-year-building-a-dating-app-that-only-lasts-one-week-e6e1a10cedb3",
+    "pubDate": "2016-02-01",
+    "source": "Medium"
+  },
+  {
+    "title": "The Broken App Store",
+    "link": "https://medium.com/ios-os-x-development/the-broken-app-store-b93a63fda292",
+    "pubDate": "2014-04-01",
+    "source": "Medium"
+  }
+]

--- a/_data/posts.json
+++ b/_data/posts.json
@@ -1,0 +1,38 @@
+[
+  {
+    "title": "AI Has No Butt To Clench",
+    "link": "https://www.bootstoobig.com/p/ai-has-no-butt-to-clench",
+    "pubDate": "Sat, 09 Aug 2025 17:36:07 GMT",
+    "source": "Substack"
+  },
+  {
+    "title": "Anti-Misalignment",
+    "link": "https://www.bootstoobig.com/p/anti-misalignment",
+    "pubDate": "Sat, 22 Mar 2025 15:25:32 GMT",
+    "source": "Substack"
+  },
+  {
+    "title": "Conviction is Good, Optionality is Better",
+    "link": "https://www.bootstoobig.com/p/conviction-is-good-optionality-is",
+    "pubDate": "Wed, 22 May 2024 15:45:44 GMT",
+    "source": "Substack"
+  },
+  {
+    "title": "My biggest leadership failure (so far)",
+    "link": "https://www.bootstoobig.com/p/my-biggest-leadership-failure-so",
+    "pubDate": "Wed, 15 May 2024 15:45:29 GMT",
+    "source": "Substack"
+  },
+  {
+    "title": "We spent a year building a dating app that only lasts one week",
+    "link": "https://medium.com/@cwRichardKim/we-spent-a-year-building-a-dating-app-that-only-lasts-one-week-e6e1a10cedb3",
+    "pubDate": "2016-02-01",
+    "source": "Medium"
+  },
+  {
+    "title": "The Broken App Store",
+    "link": "https://medium.com/ios-os-x-development/the-broken-app-store-b93a63fda292",
+    "pubDate": "2014-04-01",
+    "source": "Medium"
+  }
+]

--- a/_sass/default.scss
+++ b/_sass/default.scss
@@ -609,3 +609,46 @@ a {
   }
   /** project highlights mobile end **/
 }
+
+/* posts page */
+.posts-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 40px 20px;
+}
+
+.posts-section {
+  margin-bottom: 40px;
+}
+
+.posts-section h1,
+.posts-section h2 {
+  font-family: $title-font-family;
+  text-align: center;
+  color: #0E2736;
+}
+
+.posts-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.posts-list li {
+  margin-bottom: 10px;
+}
+
+.posts-list a {
+  color: $link-color;
+  text-decoration: none;
+}
+
+.posts-list a:hover {
+  color: $link-color-hover;
+}
+
+.posts-list .source {
+  color: $base-font-color;
+  font-size: 14px;
+  margin-left: 8px;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "generate-rss": "tsx scripts/generate-rss.ts"
+    "generate-rss": "tsx scripts/generate-rss.ts",
+    "generate-posts": "tsx scripts/generate-posts.ts"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",

--- a/posts/index.html
+++ b/posts/index.html
@@ -1,0 +1,39 @@
+---
+layout: default
+title: Posts
+popular:
+  - title: "AI Has No Butt To Clench"
+    url: "https://www.bootstoobig.com/p/ai-has-no-butt-to-clench"
+  - title: "Anti-Misalignment"
+    url: "https://www.bootstoobig.com/p/anti-misalignment"
+  - title: "We spent a year building a dating app that only lasts one week"
+    url: "https://medium.com/@cwRichardKim/we-spent-a-year-building-a-dating-app-that-only-lasts-one-week-e6e1a10cedb3"
+---
+
+<body>
+  <div class="posts-container">
+    <div class="posts-section">
+      <h1>POPULAR</h1>
+      <ul class="posts-list">
+        {% for p in page.popular %}
+          <li><a href="{{ p.url }}" target="_blank">{{ p.title }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+
+    <div class="posts-section">
+      <h2>ALL WRITING</h2>
+      <ul class="posts-list">
+        {% assign popular_links = page.popular | map: 'url' %}
+        {% for post in site.data.posts %}
+          {% unless popular_links contains post.link %}
+            <li>
+              <a href="{{ post.link }}" target="_blank">{{ post.title }}</a>
+              <span class="source">({{ post.source }})</span>
+            </li>
+          {% endunless %}
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</body>

--- a/scripts/generate-posts.ts
+++ b/scripts/generate-posts.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import { parseStringPromise } from 'xml2js';
+
+interface Post {
+  title: string;
+  link: string;
+  pubDate: string;
+  source: string;
+}
+
+async function readSubstack(): Promise<Post[]> {
+  const xml = fs.readFileSync('./rss.xml', 'utf-8');
+  const result: any = await parseStringPromise(xml);
+  const items = result?.rss?.channel?.[0]?.item || [];
+  return items.map((item: any) => ({
+    title: item.title?.[0] || '',
+    link: item.link?.[0] || '',
+    pubDate: item.pubDate?.[0] || '',
+    source: 'Substack'
+  }));
+}
+
+function readMedium(): Post[] {
+  try {
+    const raw = fs.readFileSync('./_data/medium_posts.json', 'utf-8');
+    const items = JSON.parse(raw);
+    return Array.isArray(items) ? items : [];
+  } catch {
+    return [];
+  }
+}
+
+async function generatePosts(): Promise<void> {
+  const substackPosts = await readSubstack();
+  const mediumPosts = readMedium();
+  const posts = [...substackPosts, ...mediumPosts].sort((a, b) => {
+    return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
+  });
+
+  fs.mkdirSync('./_data', { recursive: true });
+  fs.writeFileSync('./_data/posts.json', JSON.stringify(posts, null, 2));
+  console.log(`Generated _data/posts.json with ${posts.length} posts`);
+}
+
+generatePosts().catch(err => {
+  console.error('Error generating posts:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add script to generate unified posts data from Substack RSS and a static Medium list
- Create `/posts` page with a curated Popular section and combined post feed
- Style posts page to match existing theme

## Testing
- `npm run generate-posts`
- `npm run generate-rss` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689f3ed95b3c832b9574cf7c8a6dff6a