### PR TITLE
Fix mobile timeline line continuity

### DIFF
--- a/_sass/default.scss
+++ b/_sass/default.scss
@@ -525,7 +525,7 @@ $margin-top-jobs-instance: 50px;
 /* Background texture */
 .background-texture {
   position: absolute;
-  z-index: -1;
+  z-index: -10;
   inset: 0;
   // shoutout to zed.dev, i love the texture on the site
   background-image: url("/assets/noisepattern.png");


### PR DESCRIPTION
Lower `z-index` of background texture to fix broken timeline line continuity on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-e53e80d8-d854-4865-955c-d99c7fa314e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e53e80d8-d854-4865-955c-d99c7fa314e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

