### PR TITLE
Update company dates for Anthropic and Airbnb

### DIFF
--- a/_jobs/2017-08-21-airbnb.md
+++ b/_jobs/2017-08-21-airbnb.md
@@ -1,7 +1,7 @@
 ---
 company: Airbnb
 jobID: airbnb
-time: Aug 2017 - present
+time: Aug 2017 - Sept 2025
 duration:
 position: Staff Software Engineer
 show: true

--- a/_jobs/2017-08-21-airbnb.md
+++ b/_jobs/2017-08-21-airbnb.md
@@ -6,4 +6,4 @@ duration:
 position: Staff Software Engineer
 show: true
 ---
-Currently the owner of the checkout experience on web. Previously ensured hosts got paid through one of the most international payments systems in the world. Led a cost reduction and payout redundancy project that now processes billions and reduces costs by tens of millions per year. Also built host financial tools, credit card fraud detection flows, and updated payout systems to be Brexit-compliant. Experimented with [Transportation](https://news.airbnb.com/fred-reid-joins-airbnb-as-global-head-of-transportation/)!
+Owned the checkout experience on web. Most recently led 70+ contributors across five teams and produced a nine‑figure ARR lift. Previously ensured hosts got paid through one of the most international payments systems in the world. Led a cost reduction and payout redundancy project that now processes billions per year. Also built host financial tools, credit card fraud detection flows, and updated payout systems to be Brexit-compliant. Experimented with [Transportation](https://news.airbnb.com/fred-reid-joins-airbnb-as-global-head-of-transportation/)!

--- a/_jobs/2025-09-01-anthropic.md
+++ b/_jobs/2025-09-01-anthropic.md
@@ -1,0 +1,9 @@
+---
+company: Anthropic
+jobID: anthropic
+time: Sept 2025 - present
+duration:
+position: Software Engineer
+show: true
+---
+Building AI safety and alignment systems at Anthropic, working on Constitutional AI and helping to create helpful, harmless, and honest AI assistants.

--- a/_jobs/2025-09-01-anthropic.md
+++ b/_jobs/2025-09-01-anthropic.md
@@ -6,4 +6,4 @@ duration:
 position: Software Engineer
 show: true
 ---
-Building AI safety and alignment systems at Anthropic, working on Constitutional AI and helping to create helpful, harmless, and honest AI assistants.
+Helping to create helpful, harmless, and honest AI assistants at Claude.ai

--- a/_jobs/2025-09-01-anthropic.md
+++ b/_jobs/2025-09-01-anthropic.md
@@ -3,7 +3,7 @@ company: Anthropic
 jobID: anthropic
 time: Sept 2025 - present
 duration:
-position: Software Engineer
+position: Member of Technical Staff
 show: true
 ---
 Helping to create helpful, harmless, and honest AI assistants at Claude.ai


### PR DESCRIPTION
Add Anthropic job entry starting Sept 2025 and mark Airbnb job entry as ending Sept 2025.

---
<a href="https://cursor.com/background-agent?bcId=bc-4433c91d-4b58-4742-99b2-d6aaee0d6120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4433c91d-4b58-4742-99b2-d6aaee0d6120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new Anthropic job (Sept 2025–present) and updates Airbnb role to end Sept 2025 with revised summary.
> 
> - **Jobs**:
>   - **Added**: `/_jobs/2025-09-01-anthropic.md` with `Member of Technical Staff` at Anthropic (Sept 2025–present).
>   - **Updated**: `/_jobs/2017-08-21-airbnb.md`
>     - `time` changed to `Aug 2017 - Sept 2025`.
>     - Summary rewritten to reflect past ownership of checkout and leadership across five teams with ARR impact; retains payments, cost reduction, financial tools, fraud, and Brexit-compliance highlights.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 880b012555713b69bb0483b8620449e448b9f048. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a new job entry for a Member of Technical Staff at Anthropic describing work on helpful, harmless, and honest AI assistants.

- Chores
  - Updated Airbnb entry to end in Sept 2025, changed wording to past ownership highlighting leadership of 70+ contributors and a nine‑figure ARR impact; retained references to international payments, cost reduction/payout redundancy, Brexit-compliant updates, and Transportation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->