### PR TITLE
Condense less important job postings

### DIFF
--- a/_jobs/2015-01-01-drift.md
+++ b/_jobs/2015-01-01-drift.md
@@ -5,5 +5,6 @@ time: Mar 2015 - Nov 2015
 duration: 9 months
 position: Software Engineer (contract)
 show: true
+is_mini: true
 ---
-Built graphics‑editing features that doubled 7‑day retention for [Annotate iOS and OSX apps](https://drift.com) (#2 productivity iOS app).
+iOS Software Engineer (contract) | 2015 | Built graphics‑editing features that doubled 7‑day retention.

--- a/_jobs/2016-01-01-google.md
+++ b/_jobs/2016-01-01-google.md
@@ -5,5 +5,6 @@ time: Jun 2016 - Sept 2016
 duration: 4 months
 position: Software Engineering Intern
 show: true
+is_mini: true
 ---
-Built data analysis and visualization tools at Google Fiber to identify important user patterns<!--break--> such as which pages are successful or problematic in user's flow.
+Software Engineering Intern | 2016 | Created analytics dashboards that pinpointed signup‑flow friction.

--- a/_jobs/2016-01-02-privacy.md
+++ b/_jobs/2016-01-02-privacy.md
@@ -5,5 +5,6 @@ time: May 2016 - Apr 2017
 duration: 11 months
 position: Mobile Engineer
 show: true
+is_mini: true
 ---
-Built security features for credit‑card tokenization products on the [React Native](https://facebook.github.io/react-native/) [Privacy app](https://itunes.apple.com/us/app/privacy.com-forget-your-credit/id1040298266?mt=8).
+React Native Software Eng (contract) | 2016 - 2017 | Built security features for credit‑card tokenization products.

--- a/_sass/default.scss
+++ b/_sass/default.scss
@@ -410,6 +410,51 @@ $margin-top-jobs-instance: 50px;
     }
   }
 
+  // Mini job styles
+  .mini_job {
+    margin-top: 20px; // Tighter spacing than regular jobs
+    
+    .job_marker_outer {
+      width: 12px; 
+      height: 12px;
+      margin-left: calc(34.6% - 6px);
+      border-radius: 6px;
+    }
+    
+    .job_marker_inner {
+      border: 2px solid $link-color;
+      margin: 1px;
+      width: 6px; 
+      height: 6px;
+      border-radius: 6px;
+    }
+  }
+
+  .mini_job_content {
+    float: left;
+    margin-left: 60px;
+    text-align: left;
+    width: 50%;
+    max-width: 600px;
+    
+    h2 {
+      font-family: $h2-font-family;
+      letter-spacing: $h2-letter-spacing;
+      font-size: 20px; // Smaller than regular h1
+      font-weight: 500;
+      color: $h2-color;
+      margin-bottom: 4px;
+    }
+    
+    .mini_job_text {
+      font-family: $base-font-family;
+      color: $base-font-color;
+      line-height: 20px;
+      font-size: 14px;
+      margin-top: 4px;
+    }
+  }
+
 }
 
 
@@ -560,6 +605,15 @@ $margin-top-jobs-instance: 50px;
     margin-left: 63px;
     margin-top: 20px;
     width: calc(100% - 100px);
+  }
+  
+  .timeline .mini_job .job_marker_outer {
+    margin-left: 28px;
+  }
+  
+  .timeline .mini_job_content {
+    margin-left: 57px;
+    width: calc(100% - 94px);
   }
   /** timeline half screen end **/
   /* project highlights half screen */

--- a/index.html
+++ b/index.html
@@ -74,36 +74,47 @@ scripts:
 
     <div class="jobs_container">
       {% assign visible_jobs = site.jobs | where: "show", true | reverse %}
-      {% for job in visible_jobs %}
-        {% if job == visible_jobs.last %}
-        <div class="job_instance last_job">
+      {% assign regular_jobs = visible_jobs | where: "is_mini", false %}
+      {% assign mini_jobs = visible_jobs | where: "is_mini", true %}
+      {% assign all_jobs = regular_jobs | concat: mini_jobs %}
+      
+      {% for job in all_jobs %}
+        {% if job == all_jobs.last %}
+        <div class="job_instance last_job {% if job.is_mini %}mini_job{% endif %}">
         {% else %}
-        <div class="job_instance">
+        <div class="job_instance {% if job.is_mini %}mini_job{% endif %}">
         {% endif %}
 
           <div class="timeline_vert_line"></div>
           <div class="job_marker_outer"><div class="job_marker_inner"></div></div>
           <div class="job_content">
-            <div class="info_left">
-              <h1 class="blue_text">{{job.company}}</h1>
-              <p>
-                {{job.time}}
-                {% if job.duration %}
-                  <br>({{job.duration}})
-                {% elsif job.time contains "present" %}
-                  {% assign start_date = job.time | split: " - " | first %}
-                  <br><span data-start-date="{{ start_date }}"></span>
-                {% endif %}
-              </p>
-            </div>
-            <div class="info_right">
-              <h1>{{job.position}}</h1>
-              <div class="job_content_text" id="job_{{job.jobID}}">{{job.content}}</div>
-              <div class="job_content_text_mobile" id="job_{{job.jobID}}_trunc">
-                {{ job.content | split:'<!--break-->' | first }}{% if job.content contains '<!--break-->' %}...
-                <button class="textButton" onclick="readMoreClicked('{{job.jobID}}')">[read more]</button>{% endif %}
+            {% if job.is_mini %}
+              <div class="mini_job_content">
+                <h2 class="blue_text">{{job.company}}</h2>
+                <div class="mini_job_text">{{job.content}}</div>
               </div>
-            </div>
+            {% else %}
+              <div class="info_left">
+                <h1 class="blue_text">{{job.company}}</h1>
+                <p>
+                  {{job.time}}
+                  {% if job.duration %}
+                    <br>({{job.duration}})
+                  {% elsif job.time contains "present" %}
+                    {% assign start_date = job.time | split: " - " | first %}
+                    <br><span data-start-date="{{ start_date }}"></span>
+                  {% endif %}
+                </p>
+              </div>
+              <div class="info_right">
+                <h1>{{job.position}}</h1>
+                <div class="job_content_text" id="job_{{job.jobID}}">{{job.content}}</div>
+                <div class="job_content_text_mobile" id="job_{{job.jobID}}_trunc">
+                  {{ job.content | split:'<!--break-->' | first }}{% if job.content contains '<!--break-->' %}...
+                  <button class="textButton" onclick="readMoreClicked('{{job.jobID}}')">[read more]</button>{% endif %}
+                </div>
+              </div>
+            {% endif %}
             <div class="spacer" style="clear: both;"></div>
           </div>
         </div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Introduce a 'mini job' display type to visually de-emphasize less significant job postings on the timeline.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change addresses the user's request to create a visual hierarchy on the timeline, allowing smaller or less critical job experiences to be presented in a more compact and less prominent format, similar to an "Additional Experience" section on a resume. This makes the main timeline more focused and dynamic.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1c4917f-dc54-4ee0-8a77-6dd4fcb4f1de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1c4917f-dc54-4ee0-8a77-6dd4fcb4f1de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

